### PR TITLE
feat: Support writing QR code SVG and PNG to io.Writer

### DIFF
--- a/qr_code_test.go
+++ b/qr_code_test.go
@@ -304,6 +304,59 @@ func TestQrCode_PNG(t *testing.T) {
 	}
 }
 
+func TestQrCode_WriteAsPNG(t *testing.T) {
+	tests := []struct {
+		text    string
+		wantErr bool
+		ecl     Ecc
+		dest    *bytes.Buffer
+		config  *QrCodeImgConfig
+	}{
+		{
+			text:    "Hello, world!",
+			wantErr: false,
+			ecl:     Low,
+			dest:    &bytes.Buffer{},
+			config:  NewQrCodeImgConfig(10, 4),
+		},
+		{
+			text:    "",
+			wantErr: false,
+			ecl:     Low,
+			dest:    &bytes.Buffer{},
+			config:  NewQrCodeImgConfig(10, 4),
+		},
+		{
+			text:    "こんにちwa、世界！ αβγδ",
+			wantErr: false,
+			ecl:     Quartile,
+			dest:    &bytes.Buffer{},
+			config:  NewQrCodeImgConfig(10, 3),
+		},
+		{
+			text:    "aabbcc",
+			wantErr: true,
+			ecl:     Quartile,
+			dest:    nil,
+			config:  NewQrCodeImgConfig(-10, -3),
+		},
+	}
+
+	for _, tt := range tests {
+		qr, err := EncodeText(tt.text, tt.ecl)
+		if err != nil {
+			t.Errorf("EncodeText() error = %v", err)
+			return
+		}
+
+		err = qr.WriteAsPNG(tt.config, tt.dest)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("TestQrCode_WriteAsPNG() error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+	}
+}
+
 func TestNewQrCodeImgConfig(t *testing.T) {
 	colorSetterFunc := func(config *QrCodeImgConfig, light, dark color.Color) {
 		if light != nil {


### PR DESCRIPTION
This adds support for writing SVG and PNG to an `io.Writer`.

There is currently support to write the generated QR code directly to a file in these file formats.
There are, however, cases where the QR code is to be sent over the network. Without this feature, the workaround would be to write to a temporary file and then read that which is not convenient nor efficient.